### PR TITLE
Add NPC Generation macro

### DIFF
--- a/macros/generate_npc.js
+++ b/macros/generate_npc.js
@@ -1,0 +1,94 @@
+async function roll(table) {
+  table = game.tables.entities.find(t => t.name === table);
+  roll = await table.roll()
+  let processed_results = _.map(roll.results, function(result, i) {
+    id = result.data.resultId;
+    if (id == null) {
+      return result.data.text;
+    } else {
+      text = result.data.text;
+      collection = result.data.collection;
+      type = game.journal.get(id).data.flags["kanka-foundry"].type;
+      if (type == "family"){
+        text = "the " + text + " family";
+      } else if (type == "organisation") {
+        text = "the " + text;
+      }
+
+      return "@" + collection + "[" + id + "]{" + text + "}";
+    }
+  });
+  return _.reduce(processed_results, function(memo, result) { return memo + " " + result}, "").trim();
+}
+var generate_name = function() {
+  var name = null;
+  $.ajax({
+    async: false,
+    url: "https://chartopia.d12dev.com/test/dice-roll-result?chart_id=32000",
+    success: function(result){
+      name = $($.parseHTML(result)).find("p")[0].innerText;
+    }
+  });
+  return name;
+};
+
+let find_token = function(string) {
+  console.log(string);
+  let search = new RegExp(string, 'i');
+  choices = _.filter(game.moulinette.cache.cache["moulinette/images/custom/index.json"][0].packs[2].assets, function(path){
+    path_parts = _.split(path, "/");
+    token_desc = path_parts[path_parts.length - 1];
+    return token_desc.match(search);
+  });
+  if (choices.length === 0) {
+    console.log("No tokens found for " + string);
+    return null;
+  }
+  pick = _.random(0, choices.length);
+  token_file = choices[pick];
+  console.log(token_file);
+  return "moulinette/images/custom/2minutetabletop/tokens_sorted/" + token_file;
+};
+
+let [
+age,
+race,
+attitude,
+high_concept,
+trouble
+] = await Promise.all([
+roll("Age"),
+roll("Races"),
+roll("Attitude"),
+roll("High Concept"),
+roll("Trouble"),
+]);
+
+let token_disposition = 0;
+if (_.includes(["is hostile towards", "is scared of"], attitude)){
+  token_disposition = -1;
+} else if (_.includes(["is interested in", "is friendly towards", "wants something from"], attitude)) {
+  token_disposition = 1;
+}
+
+let token = find_token(race);
+if (token == null) {
+  race_bits = _.split(race, " ");
+  console.log(race_bits);
+  main_race = race_bits[race_bits.length - 1];
+  token = find_token(main_race);
+}
+
+name = generate_name();
+console.log(race);
+let description = "<b>" + name + "</b>, " + age + " " + race + " that " + attitude + " the party"
+let npc = description + "<br/><b>High Concept:</b> " + high_concept + "<br/><b>Trouble:</b> " + trouble
+avatar = "<img src='" + token + "'/>"
+let output = avatar + npc + "<br/><br/><button class='npc-create' data-name='" + name + "' data-race='" + race + "' data-npc='" + npc + "' data-token='" + token + "' data-disposition=" + token_disposition + ">Create NPC</button>"
+
+let chatData = {
+  user: game.userId,
+  speaker: ChatMessage.getSpeaker(),
+  content: output,
+};
+ChatMessage.create(chatData, {});

--- a/macros/generate_npc.js
+++ b/macros/generate_npc.js
@@ -1,3 +1,4 @@
+// Method Definitions
 async function roll(table) {
   table = game.tables.entities.find(t => t.name === table);
   roll = await table.roll()
@@ -50,6 +51,52 @@ let find_token = function(string) {
   return "moulinette/images/custom/2minutetabletop/tokens_sorted/" + token_file;
 };
 
+// Hook check
+// If this were a module, we'd have a hook on load, but it's not so we check every time
+if (game.crimsonknave && game.crimsonknave.hooked) {
+} else {
+  console.log("crimsonknave object not initialized, doing so and adding hook.");
+  game.crimsonknave = {};
+  game.crimsonknave.hooked = false;
+
+  if (Object.keys(game.moulinette.cache.cache).length === 0) {
+    ui.notifications.error("Moulinette cache not built");
+  } else {
+    let create_actor = async function(data) {
+      let actor = await Actor.create({
+        name: data.name,
+        type: "npc",
+        img: data.token
+      });
+      actor_updates = {}
+      actor_updates["data.details.biography.value"] = data.npc;
+      actor_updates["data.details.type.value"] = "humanoid";
+      actor_updates["data.details.type.subtype"] = data.race;
+      actor_updates["token.actorLink"] = true;
+      actor_updates["token.disposition"] = parseInt(data.disposition);
+
+      actor.update(actor_updates);
+    }
+
+    $(document).on('click', '.npc-create', function () {
+      data = $(this).data();
+      create_actor(data);
+      ui.notifications.info("Created " + data.name);
+
+    });
+    ui.notifications.info("NPC Creation Hook Registered");
+    game.crimsonknave.hooked = true;
+    console.log("Create NPC hook attached");
+  }
+
+}
+
+// Generate data
+
+if (game.crimsonknave.hooked == false) {
+  console.log("Not hooked, don't try to make the NPC");
+  throw "Not hooked";
+}
 let [
 age,
 race,
@@ -79,6 +126,8 @@ if (token == null) {
 }
 
 name = generate_name();
+
+// Build chat message
 let description = "<b>" + name + "</b>, " + age + " " + race + " that " + attitude + " the party";
 let npc = description + "<br/><b>High Concept:</b> " + high_concept + "<br/><b>Trouble:</b> " + trouble;
 avatar = "<img src='" + token + "'/>";
@@ -96,3 +145,4 @@ let chatData = {
   content: output,
 };
 ChatMessage.create(chatData, {});
+

--- a/macros/generate_npc.js
+++ b/macros/generate_npc.js
@@ -33,20 +33,20 @@ var generate_name = function() {
 };
 
 let find_token = function(string) {
-  console.log(string);
   let search = new RegExp(string, 'i');
   choices = _.filter(game.moulinette.cache.cache["moulinette/images/custom/index.json"][0].packs[2].assets, function(path){
     path_parts = _.split(path, "/");
+    if (path_parts[0] != "humanoid") {
+      return false;
+    }
     token_desc = path_parts[path_parts.length - 1];
     return token_desc.match(search);
   });
   if (choices.length === 0) {
-    console.log("No tokens found for " + string);
     return null;
   }
-  pick = _.random(0, choices.length);
+  pick = _.random(0, choices.length - 1);
   token_file = choices[pick];
-  console.log(token_file);
   return "moulinette/images/custom/2minutetabletop/tokens_sorted/" + token_file;
 };
 
@@ -74,17 +74,21 @@ if (_.includes(["is hostile towards", "is scared of"], attitude)){
 let token = find_token(race);
 if (token == null) {
   race_bits = _.split(race, " ");
-  console.log(race_bits);
   main_race = race_bits[race_bits.length - 1];
   token = find_token(main_race);
 }
 
 name = generate_name();
-console.log(race);
-let description = "<b>" + name + "</b>, " + age + " " + race + " that " + attitude + " the party"
-let npc = description + "<br/><b>High Concept:</b> " + high_concept + "<br/><b>Trouble:</b> " + trouble
-avatar = "<img src='" + token + "'/>"
-let output = avatar + npc + "<br/><br/><button class='npc-create' data-name='" + name + "' data-race='" + race + "' data-npc='" + npc + "' data-token='" + token + "' data-disposition=" + token_disposition + ">Create NPC</button>"
+let description = "<b>" + name + "</b>, " + age + " " + race + " that " + attitude + " the party";
+let npc = description + "<br/><b>High Concept:</b> " + high_concept + "<br/><b>Trouble:</b> " + trouble;
+avatar = "<img src='" + token + "'/>";
+button = $("<button class='npc-create'>Create NPC</button>");
+button.attr("data-name", name);
+button.attr("data-race", race);
+button.attr("data-npc", npc);
+button.attr("data-token", token);
+button.attr("data-disposition", token_disposition);
+let output = avatar + npc + "<br/><br/>" + button.get(0).outerHTML
 
 let chatData = {
   user: game.userId,

--- a/macros/hook_create.js
+++ b/macros/hook_create.js
@@ -1,3 +1,4 @@
+// Deprecated, folded this functionality into the create macro
 if (Object.keys(game.moulinette.cache.cache).length === 0) {
   ui.notifications.error("Moulinette cache not built");
 } else {

--- a/macros/hook_create.js
+++ b/macros/hook_create.js
@@ -1,0 +1,28 @@
+if (Object.keys(game.moulinette.cache.cache).length === 0) {
+  ui.notifications.error("Moulinette cache not built");
+} else {
+  let create_actor = async function(data) {
+    let actor = await Actor.create({
+      name: data.name,
+      type: "npc",
+      img: data.token
+    });
+    actor_updates = {}
+    actor_updates["data.details.biography.value"] = data.npc;
+    actor_updates["data.details.type.value"] = "humanoid";
+    actor_updates["data.details.type.subtype"] = data.race;
+    actor_updates["token.actorLink"] = true;
+    actor_updates["token.disposition"] = parseInt(data.disposition);
+
+    actor.update(actor_updates);
+    console.log(actor);
+  }
+
+  $(document).on('click', '.npc-create', function () {
+    data = $(this).data();
+    create_actor(data);
+    ui.notifications.info("Created " + data.name);
+
+  });
+  ui.notifications.info("NPC Creation Hook Registered");
+}


### PR DESCRIPTION
The `generate_npc.js` macro will roll on a set of tables I have, get randomly generated fields and then post a proposed NPC into chat with a button to make them an actor. If that button is pressed it'll create an actor for the NPC and set some stuff in their sheet and on the prototype token.

:grimacing: this is pretty rough js in some places, but it seems to work pretty well right now. If this were a real module the button hook would be in an initialize somewhere, but it's not, so we check every time instead of making you hit another macro.

The biggest thing I'd like to fix is to use the  `Token Variants` cache, but that needs APIs exposed (https://github.com/Aedif/TokenVariants/issues/31) or to find a way to trigger the moulinette cache on demand, which I will probably file an issue about. Once one of those is complete then nothing manual will need to be done, right now, you have to open a moulinette something to trigger the index, but we alert if you haven't, so that's something.

I brought the hook into the create macro, but leaving the standalone hook for reference.